### PR TITLE
Decouple relex from tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lr
 
-A minimal LR parser generator framework designed to work alongside [relex](https://github.com/ncatelli/relex) to build LR parsers that tightly couple with built in types, namely enums. 
+A minimal LR parser generator framework designed to (optionally) work alongside [relex](https://github.com/ncatelli/relex) to build LR parsers that tightly couple with built in types, namely enums. 
 
 ## Examples
 Defining grammars on an enum can be handled at compile type by specifying a set of productions, and a goal on variants of an enum.

--- a/lr-derive/Cargo.toml
+++ b/lr-derive/Cargo.toml
@@ -8,9 +8,12 @@ workspace = ".."
 proc-macro = true
 
 [dependencies]
-regex-runtime = { git = "https://github.com/ncatelli/regex", branch = "main" }
-relex-derive = { git = "https://github.com/ncatelli/relex", branch = "main" }
 lr-core = { path = "../lr-core" }
-syn = { version = "1.0", features = ["derive", "parsing", "full"] }
+syn = { version = "1.0", features = [
+	"derive",
+	"parsing",
+	"extra-traits",
+	"full",
+] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/lr-tests/Cargo.toml
+++ b/lr-tests/Cargo.toml
@@ -4,7 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-regex-runtime = { git = "https://github.com/ncatelli/regex", branch = "main" }
-relex-derive = { git = "https://github.com/ncatelli/relex", branch = "main" }
 lr-core = { path = "../lr-core" }
 lr-derive = { path = "../lr-derive" }

--- a/lr-tests/tests/basic.rs
+++ b/lr-tests/tests/basic.rs
@@ -1,18 +1,13 @@
 use lr_core::{TerminalOrNonTerminal, TerminalRepresentable};
 pub use lr_derive::Lr1;
-pub use relex_derive::{Relex, VariantKind};
 
-#[derive(VariantKind, Relex, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Terminal {
-    #[matches(r"+")]
     Plus,
-    #[matches(r"*")]
+    #[allow(unused)]
     Star,
-    #[matches(r"0")]
     Zero,
-    #[matches(r"1")]
     One,
-    #[eoi]
     Eof,
 }
 
@@ -32,14 +27,14 @@ impl std::fmt::Display for Terminal {
 
 impl TerminalRepresentable for Terminal {
     /// the associated type representing the variant kind.
-    type Repr = <Self as VariantKindRepresentable>::Output;
+    type Repr = Self;
 
     fn eof() -> Self::Repr {
         Self::Repr::Eof
     }
 
     fn to_variant_repr(&self) -> Self::Repr {
-        self.to_variant_kind()
+        *self
     }
 }
 
@@ -118,13 +113,8 @@ pub enum NonTerminal {
 
 #[test]
 fn derived_macro_generator_functionality_test() {
-    let input = "1 + 0";
-    let tokenizer = token_stream_from_input(input)
-        .unwrap()
-        .map(|token| token.to_variant())
-        .take_while(|terminal| !matches!(&terminal, &Terminal::Eof))
-        // append a single eof.
-        .chain([Terminal::Eof].into_iter());
+    let input = [Terminal::One, Terminal::Plus, Terminal::Zero, Terminal::Eof];
+    let tokenizer = input.into_iter();
 
     let parse_tree = lr_parse_input(tokenizer);
 

--- a/lr-tests/tests/embedded_values.rs
+++ b/lr-tests/tests/embedded_values.rs
@@ -1,42 +1,60 @@
 use lr_core::{TerminalOrNonTerminal, TerminalRepresentable};
 pub use lr_derive::Lr1;
-pub use relex_derive::{Relex, VariantKind};
 
-#[derive(VariantKind, Relex, Debug, Clone, PartialEq, Eq)]
-pub enum Terminal {
-    #[matches(r"+")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalKind {
     Plus,
-    #[matches(r"*")]
     Star,
-    #[matches(r"[0-9]+", |lex: &str| { lex.parse::<i64>().ok() })]
+    Int,
+    Eof,
+}
+
+impl std::fmt::Display for TerminalKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Plus => write!(f, "+"),
+            Self::Star => write!(f, "*"),
+            Self::Int => write!(f, "int",),
+            Self::Eof => write!(f, "<$>"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Terminal {
+    Plus,
+    #[allow(unused)]
+    Star,
     Int(i64),
-    #[eoi]
     Eof,
 }
 
 impl std::fmt::Display for Terminal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let repr = match self {
-            Self::Plus => "+".to_string(),
-            Self::Star => "*".to_string(),
-            Self::Int(i) => format!("{}", i),
-            Self::Eof => "<$>".to_string(),
-        };
-
-        write!(f, "{}", repr)
+        match self {
+            Self::Plus => write!(f, "+"),
+            Self::Star => write!(f, "*"),
+            Self::Int(i) => write!(f, "{}", i),
+            Self::Eof => write!(f, "<$>"),
+        }
     }
 }
 
 impl TerminalRepresentable for Terminal {
     /// the associated type representing the variant kind.
-    type Repr = <Self as VariantKindRepresentable>::Output;
+    type Repr = TerminalKind;
 
     fn eof() -> Self::Repr {
         Self::Repr::Eof
     }
 
     fn to_variant_repr(&self) -> Self::Repr {
-        self.to_variant_kind()
+        match self {
+            Self::Plus => Self::Repr::Plus,
+            Self::Star => Self::Repr::Star,
+            Self::Int(_) => Self::Repr::Int,
+            Self::Eof => Self::Repr::Eof,
+        }
     }
 }
 
@@ -104,23 +122,23 @@ fn reduce_e_binary_non_term(
 #[derive(Debug, Lr1, PartialEq)]
 pub enum NonTerminal {
     #[goal(r"<E>", reduce_e_unary_non_term)]
-    #[production(r"<E> Terminal::Star <B>", |elems| { reduce_e_binary_non_term(2, elems) })]
-    #[production(r"<E> Terminal::Plus <B>", |elems| { reduce_e_binary_non_term(3, elems) })]
+    #[production(r"<E> TerminalKind::Star <B>", |elems| { reduce_e_binary_non_term(2, elems) })]
+    #[production(r"<E> TerminalKind::Plus <B>", |elems| { reduce_e_binary_non_term(3, elems) })]
     #[production(r"<B>", reduce_e_unary_non_term)]
     E(Box<NonTermKind>),
-    #[production(r"Terminal::Int", reduce_b_non_term)]
+    #[production(r"TerminalKind::Int", reduce_b_non_term)]
     B(Terminal),
 }
 
 #[test]
 fn derived_macro_generator_should_parse_tokens_with_embedded_values() {
-    let input = "10 + 1";
-    let tokenizer = token_stream_from_input(input)
-        .unwrap()
-        .map(|token| token.to_variant())
-        .take_while(|terminal| !matches!(&terminal, &Terminal::Eof))
-        // append a single eof.
-        .chain([Terminal::Eof].into_iter());
+    let input = [
+        Terminal::Int(10),
+        Terminal::Plus,
+        Terminal::Int(1),
+        Terminal::Eof,
+    ];
+    let tokenizer = input.into_iter();
 
     let parse_tree = lr_parse_input(tokenizer);
 


### PR DESCRIPTION
# Introduction
This PR removes a dependence on relex, most specifically for testing. The hope is that removing this dependence will make testing and benchmarking better reflect actually performance of the library.

# Linked Issues
resolves #13 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
