### PR TITLE
Bump syn dependency to 2+

### DIFF
--- a/lr-derive/Cargo.toml
+++ b/lr-derive/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 
 [dependencies]
 lr-core = { path = "../lr-core" }
-syn = { version = "1.0", features = [
+syn = { version = "2.0", features = [
 	"derive",
 	"parsing",
 	"extra-traits",


### PR DESCRIPTION
# Introduction
This PR bumps the syn dependency for proc macros from 1.0+ -> 2.0+. This also strips out some unused uses of the `Spanned` trait which was sealed in the major version bump.

# Linked Issues
resolves #15 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
