### PR TITLE
Remove uses of context-unaware followsets from closure generation

### DIFF
--- a/lr-core/src/grammar.rs
+++ b/lr-core/src/grammar.rs
@@ -59,7 +59,7 @@ impl<'a> std::fmt::Display for Symbol<'a> {
 }
 
 /// A wrapper type for non-terminals that reference the grammar table.
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NonTerminalRef(usize);
 
 impl NonTerminalRef {
@@ -88,7 +88,7 @@ impl std::fmt::Display for NonTerminalRef {
 }
 
 /// A wrapper type for terminals that reference the grammar table.
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TerminalRef(usize);
 
 impl TerminalRef {

--- a/lr-core/src/grammar.rs
+++ b/lr-core/src/grammar.rs
@@ -117,7 +117,7 @@ impl std::fmt::Display for TerminalRef {
 }
 
 /// An enum for storing a symbol reference id within a given grammar.
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SymbolRef {
     NonTerminal(NonTerminalRef),
     Terminal(TerminalRef),
@@ -133,7 +133,7 @@ impl std::fmt::Display for SymbolRef {
 }
 
 /// A structure representing a grammar production. Containing valid references to a
-#[derive(Debug, Hash, Clone, PartialEq, Eq)]
+#[derive(Debug, Hash, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProductionRef {
     /// The left-hand side symbol of a production
     pub lhs: NonTerminalRef,

--- a/lr-core/src/lr.rs
+++ b/lr-core/src/lr.rs
@@ -122,7 +122,7 @@ impl SymbolRefSet {
     }
 }
 
-impl<'a> AsRef<HashMap<NonTerminalRef, HashSet<TerminalRef>>> for SymbolRefSet {
+impl AsRef<HashMap<NonTerminalRef, HashSet<TerminalRef>>> for SymbolRefSet {
     fn as_ref(&self) -> &HashMap<NonTerminalRef, HashSet<TerminalRef>> {
         &self.sets
     }
@@ -468,7 +468,7 @@ fn closure<'a>(grammar_table: &'a GrammarTable, i: ItemSet<'a>) -> ItemSet<'a> {
             if let Some(non_terminal_ref) = maybe_next_symbol_after_dot_is_non_terminal {
                 let follow_set = {
                     let lookahead_set = [SymbolRef::Terminal(lookahead)];
-                    let mut follow_set = first(&first_symbolref_set, &[&lookahead_set, &beta])
+                    let mut follow_set = first(&first_symbolref_set, &[&lookahead_set, beta])
                         .into_iter()
                         .collect::<Vec<_>>();
 


### PR DESCRIPTION
# Introduction
This PR removes the use of a global followset in favor of context aware followsets for generating a state table.
# Linked Issues
resolves #30 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
