### PR TITLE
Fix set generation when lookheads are out of order

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,22 @@
 {
 	"name": "Rust",
-	"image": "mcr.microsoft.com/devcontainers/rust:1-bullseye"
-
+	"image": "mcr.microsoft.com/devcontainers/rust:1-bullseye",
 	// Features to add to the dev container. More info: https://containers.dev/implementors/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "rustc --version",
-
 	// Configure tool-specific properties.
-	// "customizations": {},
-
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"rust-analyzer.checkOnSave.command": "clippy"
+			}
+		}
+	}
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/lr-core/src/lr/mod.rs
+++ b/lr-core/src/lr/mod.rs
@@ -452,12 +452,16 @@ fn closure<'a>(grammar_table: &'a GrammarTable, i: ItemSet<'a>) -> ItemSet<'a> {
     let first_symbolref_set = build_first_set_ref(grammar_table, &nullable_nonterms);
 
     let mut set = i.items;
+    let mut next_iteration = set.clone();
 
     let mut changed = true;
     while changed {
         changed = false;
 
-        for item in set.clone() {
+        let current_iteration = next_iteration.clone();
+        next_iteration.clear();
+
+        for item in current_iteration {
             let lookahead = item.lookahead;
             let beta = item.beta();
             let symbol_after_dot_position = item.symbol_after_dot();
@@ -488,6 +492,7 @@ fn closure<'a>(grammar_table: &'a GrammarTable, i: ItemSet<'a>) -> ItemSet<'a> {
                     for new in new_item {
                         let new_item_inserted = set.insert(new.clone());
                         if new_item_inserted {
+                            next_iteration.insert(new);
                             changed = true;
                         }
                     }

--- a/lr-core/src/lr/mod.rs
+++ b/lr-core/src/lr/mod.rs
@@ -1279,7 +1279,7 @@ mod tests {
     }
 
     #[test]
-    fn should_correctly_generate_closure_sets_for_recursive_grammar_two() {
+    fn should_correctly_generate_closure_sets_for_larger_grammar() {
         GrammarTestCase::default()
             .with_grammar(
                 "

--- a/lr-core/src/lr/mod.rs
+++ b/lr-core/src/lr/mod.rs
@@ -940,7 +940,7 @@ fn build_table<'a>(
                 .item_sets
                 .as_ref()
                 .iter()
-                .position(|sx| sk.items.as_ref().starts_with(&sx.items.as_ref()));
+                .position(|sx| sk.items.as_ref().starts_with(sx.items.as_ref()));
 
             if let Some(k) = k {
                 goto_table[n.as_usize()][x] = Goto::State(k);
@@ -1036,7 +1036,7 @@ mod tests {
                     .filter_map(|t| terminals.get(t.as_usize()).cloned())
                     .collect::<HashSet<_>>();
 
-                (nonterminals[nt.as_usize()].clone(), terms)
+                (nonterminals[nt.as_usize()], terms)
             })
             .collect::<Vec<_>>();
         got.sort_by(|(a, _), (b, _)| a.as_ref().cmp(b.as_ref()));
@@ -1194,7 +1194,7 @@ mod tests {
 
     impl<'a> GrammarTestCase<'a> {
         fn test(&self) {
-            let grammar_table = load_grammar(&self.grammar_table).unwrap();
+            let grammar_table = load_grammar(self.grammar_table).unwrap();
             let nullable_terms = find_nullable_nonterminals(&grammar_table);
             let first_sets = build_first_set_ref(&grammar_table, &nullable_terms);
 

--- a/lr-core/src/lr/ordered_set.rs
+++ b/lr-core/src/lr/ordered_set.rs
@@ -38,6 +38,12 @@ impl<T: Hash> OrderedSet<T> {
         }
     }
 
+    /// Clears all elements from the ordered set.
+    pub fn clear(&mut self) {
+        self.elem_idx.clear();
+        self.elems.clear();
+    }
+
     /// Returns the position of a given element is a member the set, otherwise
     /// `None` is returned.
     pub fn position(&self, elem: &T) -> Option<usize> {

--- a/lr-core/src/lr/ordered_set.rs
+++ b/lr-core/src/lr/ordered_set.rs
@@ -8,6 +8,13 @@ pub(crate) struct OrderedSet<T: Hash> {
 }
 
 impl<T: Hash> OrderedSet<T> {
+    pub fn new() -> Self {
+        Self {
+            elem_idx: Default::default(),
+            elems: Default::default(),
+        }
+    }
+
     /// Returns a boolean signifying if the set is empty.
     pub fn is_empty(&self) -> bool {
         self.elems.is_empty()
@@ -39,6 +46,7 @@ impl<T: Hash> OrderedSet<T> {
     }
 
     /// Clears all elements from the ordered set.
+    #[allow(unused)]
     pub fn clear(&mut self) {
         self.elem_idx.clear();
         self.elems.clear();
@@ -55,6 +63,7 @@ impl<T: Hash> OrderedSet<T> {
     }
 
     /// Returns a boolean signifying if a given element is a member of the set.
+    #[allow(unused)]
     pub fn contains(&self, elem: &T) -> bool {
         self.position(elem).is_some()
     }
@@ -120,9 +129,6 @@ impl<T: Hash> From<OrderedSet<T>> for Vec<T> {
 
 impl<T: Hash> Default for OrderedSet<T> {
     fn default() -> Self {
-        Self {
-            elem_idx: Default::default(),
-            elems: Default::default(),
-        }
+        Self::new()
     }
 }

--- a/lr-core/src/lr/ordered_set.rs
+++ b/lr-core/src/lr/ordered_set.rs
@@ -35,8 +35,8 @@ impl<T: Hash> OrderedSet<T> {
 
         let slot = self.elems.len();
 
-        if !self.elem_idx.contains_key(&elem_hash) {
-            self.elem_idx.insert(elem_hash, slot);
+        if let std::collections::hash_map::Entry::Vacant(e) = self.elem_idx.entry(elem_hash) {
+            e.insert(slot);
             self.elems.push(elem);
 
             true
@@ -68,7 +68,7 @@ impl<T: Hash> OrderedSet<T> {
         self.position(elem).is_some()
     }
 
-    pub fn to_vec(self) -> Vec<T> {
+    pub fn into_vec(self) -> Vec<T> {
         self.elems
     }
 }
@@ -123,7 +123,7 @@ impl<T: Hash> Hash for OrderedSet<T> {
 
 impl<T: Hash> From<OrderedSet<T>> for Vec<T> {
     fn from(value: OrderedSet<T>) -> Self {
-        value.to_vec()
+        value.into_vec()
     }
 }
 

--- a/lr-core/src/lr/ordered_set.rs
+++ b/lr-core/src/lr/ordered_set.rs
@@ -52,6 +52,10 @@ impl<T: Hash> OrderedSet<T> {
     pub fn contains(&self, elem: &T) -> bool {
         self.position(elem).is_some()
     }
+
+    pub fn to_vec(self) -> Vec<T> {
+        self.elems
+    }
 }
 
 impl<T: Hash> AsRef<[T]> for OrderedSet<T> {
@@ -99,6 +103,12 @@ impl<T: Hash> FromIterator<T> for OrderedSet<T> {
 impl<T: Hash> Hash for OrderedSet<T> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.elems.hash(state);
+    }
+}
+
+impl<T: Hash> From<OrderedSet<T>> for Vec<T> {
+    fn from(value: OrderedSet<T>) -> Self {
+        value.to_vec()
     }
 }
 

--- a/lr-tests/benches/nested_token_expression_parsing.rs
+++ b/lr-tests/benches/nested_token_expression_parsing.rs
@@ -202,7 +202,7 @@ fn reduce_additive_binary(elems: &mut Vec<TermOrNonTerm>) -> Result<NonTerminal,
 
         Ok(NonTerminal::Additive(Box::new(inner)))
     } else {
-        let err_msg = format!("expected 3 elements at top of stack in production  reducer.",);
+        let err_msg = "expected 3 elements at top of stack in production  reducer.".to_string();
         Err(err_msg)
     }
 }
@@ -260,7 +260,7 @@ fn parse_basic_expression(c: &mut Criterion) {
         let expected = Ok(expected);
 
         b.iter(|| {
-            let parse_tree = NonTerminal::parse_input(black_box((&token_stream).iter().copied()));
+            let parse_tree = NonTerminal::parse_input(black_box(token_stream.iter().copied()));
             assert_eq!(&parse_tree, &expected);
         });
     });
@@ -287,7 +287,7 @@ fn parse_large_expression(c: &mut Criterion) {
 
     group.bench_function("without tokenization", |b| {
         b.iter(|| {
-            let parse_tree = NonTerminal::parse_input(black_box((&token_stream).iter().copied()));
+            let parse_tree = NonTerminal::parse_input(black_box(token_stream.iter().copied()));
             assert!(parse_tree.is_ok());
         });
     });

--- a/lr-tests/tests/basic.rs
+++ b/lr-tests/tests/basic.rs
@@ -64,9 +64,7 @@ fn reduce_e_unary_non_term(elems: &mut Vec<TermOrNonTerm>) -> Result<NonTerminal
 
         Ok(NonTerminal::E(Box::new(non_term_kind)))
     } else {
-        Err(format!(
-            "expected non-terminal at top of stack in production 3 reducer.",
-        ))
+        Err("expected non-terminal at top of stack in production 3 reducer.".to_string())
     }
 }
 
@@ -105,9 +103,7 @@ fn reduce_goal(elems: &mut Vec<TermOrNonTerm>) -> Result<NonTerminal, String> {
     if let Some(TermOrNonTerm::NonTerminal(NonTerminal::E(e))) = elems.pop() {
         Ok(NonTerminal::E(e))
     } else {
-        Err(format!(
-            "expected non-terminal at top of stack in production 3 reducer.",
-        ))
+        Err("expected non-terminal at top of stack in production 3 reducer.".to_string())
     }
 }
 

--- a/lr-tests/tests/embedded_values.rs
+++ b/lr-tests/tests/embedded_values.rs
@@ -84,9 +84,7 @@ fn reduce_e_unary_non_term(elems: &mut Vec<TermOrNonTerm>) -> Result<NonTerminal
 
         Ok(NonTerminal::E(Box::new(non_term_kind)))
     } else {
-        Err(format!(
-            "expected non-terminal at top of stack in production 3 reducer.",
-        ))
+        Err("expected non-terminal at top of stack in production 3 reducer.".to_string())
     }
 }
 
@@ -125,9 +123,7 @@ fn reduce_goal(elems: &mut Vec<TermOrNonTerm>) -> Result<NonTerminal, String> {
     if let Some(TermOrNonTerm::NonTerminal(NonTerminal::E(e))) = elems.pop() {
         Ok(NonTerminal::E(e))
     } else {
-        Err(format!(
-            "expected non-terminal at top of stack in production 3 reducer.",
-        ))
+        Err("expected non-terminal at top of stack in production 3 reducer.".to_string())
     }
 }
 

--- a/lr-tests/tests/stateful.rs
+++ b/lr-tests/tests/stateful.rs
@@ -84,9 +84,7 @@ fn reduce_e_unary_non_term(elems: &mut Vec<TermOrNonTerm>) -> Result<NonTerminal
 
         Ok(NonTerminal::E(Box::new(non_term_kind)))
     } else {
-        Err(format!(
-            "expected non-terminal at top of stack in production 3 reducer.",
-        ))
+        Err("expected non-terminal at top of stack in production 3 reducer.".to_string())
     }
 }
 
@@ -125,9 +123,7 @@ fn reduce_goal(elems: &mut Vec<TermOrNonTerm>) -> Result<NonTerminal, String> {
     if let Some(TermOrNonTerm::NonTerminal(NonTerminal::E(e))) = elems.pop() {
         Ok(NonTerminal::E(e))
     } else {
-        Err(format!(
-            "expected non-terminal at top of stack in production 3 reducer.",
-        ))
+        Err("expected non-terminal at top of stack in production 3 reducer.".to_string())
     }
 }
 

--- a/lr-tests/tests/stateful_with_tokens_with_references.rs
+++ b/lr-tests/tests/stateful_with_tokens_with_references.rs
@@ -84,9 +84,7 @@ fn reduce_e_unary_non_term<'a>(
 
         Ok(NonTerminal::E(Box::new(non_term_kind)))
     } else {
-        Err(format!(
-            "expected non-terminal at top of stack in production 3 reducer.",
-        ))
+        Err("expected non-terminal at top of stack in production 3 reducer.".to_string())
     }
 }
 
@@ -125,9 +123,7 @@ fn reduce_goal<'a>(elems: &mut Vec<TermOrNonTerm<'a>>) -> Result<NonTerminal<'a>
     if let Some(TermOrNonTerm::NonTerminal(NonTerminal::E(e))) = elems.pop() {
         Ok(NonTerminal::E(e))
     } else {
-        Err(format!(
-            "expected non-terminal at top of stack in production 3 reducer.",
-        ))
+        Err("expected non-terminal at top of stack in production 3 reducer.".to_string())
     }
 }
 

--- a/lr-tests/tests/tokens_with_references.rs
+++ b/lr-tests/tests/tokens_with_references.rs
@@ -84,9 +84,7 @@ fn reduce_e_unary_non_term<'a>(
 
         Ok(NonTerminal::E(Box::new(non_term_kind)))
     } else {
-        Err(format!(
-            "expected non-terminal at top of stack in production 3 reducer.",
-        ))
+        Err("expected non-terminal at top of stack in production 3 reducer.".to_string())
     }
 }
 
@@ -125,9 +123,7 @@ fn reduce_goal<'a>(elems: &mut Vec<TermOrNonTerm<'a>>) -> Result<NonTerminal<'a>
     if let Some(TermOrNonTerm::NonTerminal(NonTerminal::E(e))) = elems.pop() {
         Ok(NonTerminal::E(e))
     } else {
-        Err(format!(
-            "expected non-terminal at top of stack in production 3 reducer.",
-        ))
+        Err("expected non-terminal at top of stack in production 3 reducer.".to_string())
     }
 }
 


### PR DESCRIPTION
# Introduction
This PR addresses an issue where first and follow sets could be out of order due to using the `HashSet` from `std` for lookahead symbols rather than the internal `OrderedSet`.

# Linked Issues
#39
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
