### PR TITLE
Remove repeated iteration of old closure items

### DIFF
--- a/lr-core/src/lr/mod.rs
+++ b/lr-core/src/lr/mod.rs
@@ -291,10 +291,15 @@ fn closure<'a>(grammar_table: &'a GrammarTable, i: ItemSet<'a>) -> ItemSet<'a> {
     let mut set = i.items;
 
     let mut changed = true;
+    let mut last_modified_cnt = 0;
     while changed {
         changed = false;
 
-        for item in set.clone() {
+        // build a list of all new items and update the modified count.
+        let new_items_in_set = set.as_ref()[last_modified_cnt..].to_vec();
+        last_modified_cnt = new_items_in_set.len();
+
+        for item in new_items_in_set {
             let lookahead = item.lookahead;
             let beta = item.beta();
             let symbol_after_dot_position = item.symbol_after_dot();

--- a/lr-core/src/lr/mod.rs
+++ b/lr-core/src/lr/mod.rs
@@ -314,8 +314,6 @@ fn closure<'a>(grammar_table: &'a GrammarTable, i: ItemSet<'a>) -> ItemSet<'a> {
                 let follow_set = {
                     let lookahead_set = [SymbolRef::Terminal(lookahead)];
                     follow(grammar_table.first_set(), &[beta, &lookahead_set])
-                        .into_iter()
-                        .collect::<Vec<_>>()
                 };
 
                 let matching_productions = grammar_table


### PR DESCRIPTION
# Introduction
This PR updates the LR closure to only operate on new set items.

## Benchmark
Initial tests show an improvement of ~25% throughput and I expect this to scale significantly as the set size increases.

```
Benchmarking lr1 table generation: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.0s, or reduce sample count to 80.
lr1 table generation    time:   [59.727 ms 59.867 ms 60.058 ms]
                        change: [-26.632% -26.358% -26.065%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  8 (8.00%) high mild
  7 (7.00%) high severe
```
# Linked Issues
#41 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
